### PR TITLE
Fix: user service request dto 불필요한 필드 제거

### DIFF
--- a/protos/user/v1/user.proto
+++ b/protos/user/v1/user.proto
@@ -2,10 +2,6 @@ syntax = "proto3";
 
 package user.v1;
 
-enum AuthProvider {
-  KEYCLOAK = 0;
-}
-
 message UserSummary {
   string user_id = 1;
   string nickname = 2;

--- a/protos/user/v1/user_service.proto
+++ b/protos/user/v1/user_service.proto
@@ -4,26 +4,19 @@ package user.v1;
 
 import "user/v1/user.proto";
 
-
 service UserService {
   rpc CreateRandomNicknameUser(CreateRandomNicknameUserRequest) returns (CreateRandomNicknameUserResponse);
 
   rpc FindUserByAuth(FindUserByAuthRequest) returns (FindUserByAuthResponse);
 }
 
-message CreateRandomNicknameUserRequest {
-  AuthProvider auth_provider = 1;
-  string auth_id = 2;
-}
+message CreateRandomNicknameUserRequest {}
 
 message CreateRandomNicknameUserResponse {
   UserSummary user = 1;
 }
 
-message FindUserByAuthRequest {
-  AuthProvider auth_provider = 1;
-  string auth_id = 2;
-}
+message FindUserByAuthRequest {}
 
 message FindUserByAuthResponse {
   optional UserSummary user = 1;


### PR DESCRIPTION
### 변경 목적 (Why)
- user service의 request dto의 필드값들은 grpc 헤더로 전달하도록 수정

### 주요 변경점 (What)
- user service의 request dto의 필드값들을 제거